### PR TITLE
Remove redundant `run-name` declarations from workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches: [ "main" ]
 
-run-name: Deploy to ${{ inputs.deploy_target }} by @${{ github.actor }}
-
 jobs:
   build:
     name: Gradle build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-run-name: Deploy to ${{ inputs.deploy_target }} by @${{ github.actor }}
 jobs:
   parse_branch_name:
     runs-on: self-hosted


### PR DESCRIPTION
The `run-name` fields in both `main.yml` and `pr.yml` workflows were unnecessary and have been removed. This simplifies the configuration and ensures consistency across workflow files. No functional changes are introduced.